### PR TITLE
Add initial login component for google sign in

### DIFF
--- a/tabu-app/.env
+++ b/tabu-app/.env
@@ -1,0 +1,2 @@
+VITE_APP_GOOGLE_CLIENT_ID=881939165116-d8tp8es5j5v6trie65vh5feaa8op9erg.apps.googleusercontent.com
+VITE_API_ENDPOINT=http://localhost:3000/

--- a/tabu-app/.env
+++ b/tabu-app/.env
@@ -1,2 +1,0 @@
-VITE_APP_GOOGLE_CLIENT_ID=881939165116-d8tp8es5j5v6trie65vh5feaa8op9erg.apps.googleusercontent.com
-VITE_API_ENDPOINT=http://localhost:3000/

--- a/tabu-app/.env.example
+++ b/tabu-app/.env.example
@@ -1,0 +1,4 @@
+# Request from project owner or use your own client ID
+VITE_APP_GOOGLE_CLIENT_ID=<google_client_id>
+# Set to tabu-db-api backend server (defaults to default docker container)
+VITE_API_ENDPOINT=http://localhost:3001/

--- a/tabu-app/.gitignore
+++ b/tabu-app/.gitignore
@@ -20,8 +20,8 @@ coverage
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
-.idea
-../.idea
+.idea/
+../.idea/
 *.suo
 *.ntvs*
 *.njsproj

--- a/tabu-app/package-lock.json
+++ b/tabu-app/package-lock.json
@@ -8,8 +8,10 @@
       "name": "tabu-app",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "vue": "^3.5.12",
-        "vue-router": "^4.4.5"
+        "vue-router": "^4.4.5",
+        "vue3-google-login": "^2.0.33"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.4",
@@ -2489,8 +2491,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2697,7 +2709,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2921,7 +2932,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3517,6 +3527,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -3538,7 +3568,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4262,7 +4291,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4272,7 +4300,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4802,6 +4829,12 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5915,6 +5948,15 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vue3-google-login": {
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/vue3-google-login/-/vue3-google-login-2.0.33.tgz",
+      "integrity": "sha512-Hx3JJUREXWCFOOB4AzZKy/x7C+X18kxmT0AquBekm0TRubp11nrWijOLEgmhuij48dQPNumyaAi5IQAeDKk7yw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.0.3"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/tabu-app/package.json
+++ b/tabu-app/package.json
@@ -14,8 +14,10 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "vue": "^3.5.12",
-    "vue-router": "^4.4.5"
+    "vue-router": "^4.4.5",
+    "vue3-google-login": "^2.0.33"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",

--- a/tabu-app/src/App.vue
+++ b/tabu-app/src/App.vue
@@ -14,7 +14,8 @@ import { RouterLink, RouterView } from 'vue-router'
 
     <div class="wrapper">
       <nav>
-        <RouterLink to="/">Login</RouterLink>
+        <RouterLink to="/home">Home</RouterLink>
+        <RouterLink to="/login">Login</RouterLink>
         <RouterLink to="/about">About</RouterLink>
       </nav>
     </div>

--- a/tabu-app/src/components/HomeItem.vue
+++ b/tabu-app/src/components/HomeItem.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import router from '@/router'
+import IconTabu from '@/components/icons/IconTabu.vue'
+
+type UserData = {
+  name: string
+  email: string
+}
+
+let userData = ref<UserData>({
+  name: '',
+  email: '',
+})
+onMounted(() => {
+  let localStorageString = localStorage.getItem('userData') ?? ''
+  if (localStorageString === '') {
+    router.push('/login')
+  } else {
+    userData.value = JSON.parse(localStorageString) as UserData
+  }
+})
+</script>
+
+<template>
+  <icon-tabu />
+  <div>Logged in as {{ userData.name }}</div>
+</template>

--- a/tabu-app/src/components/HomeItem.vue
+++ b/tabu-app/src/components/HomeItem.vue
@@ -5,12 +5,10 @@ import IconTabu from '@/components/icons/IconTabu.vue'
 
 type UserData = {
   name: string
-  email: string
 }
 
 let userData = ref<UserData>({
   name: '',
-  email: '',
 })
 onMounted(() => {
   let localStorageString = localStorage.getItem('userData') ?? ''

--- a/tabu-app/src/components/LoginItem.vue
+++ b/tabu-app/src/components/LoginItem.vue
@@ -1,8 +1,36 @@
 <script setup lang="ts">
-import IconTabu from '@/components/icons/IconTabu.vue'
+import { decodeCredential, GoogleLogin } from 'vue3-google-login'
+import type { CallbackTypes } from 'vue3-google-login'
+import { googleLogin } from '@/services/auth/google'
+import router from '@/router'
+
+type GoogleUserData = {
+  email: string
+  given_name: string
+}
+
+const callback: CallbackTypes.CredentialCallback = async response => {
+  // This callback will be triggered when the user selects or login to his Google account from the popup
+  const userData: GoogleUserData = decodeCredential(
+    response.credential,
+  ) as GoogleUserData
+  googleLogin(userData.given_name, userData.email).then(function (resp) {
+    if (resp.data.success) {
+      console.log('Successfully logged in', resp.data.response)
+      const localUser = {
+        name: resp.data.response.name,
+        email: resp.data.response.email,
+      }
+      localStorage.setItem('userData', JSON.stringify(localUser))
+      router.push({ path: 'home' })
+    } else {
+      console.log('Error', resp.data.error ?? ' logging in!')
+    }
+  })
+}
 </script>
 
 <template>
   <div>Login to Tabu</div>
-  <icon-tabu />
+  <GoogleLogin :callback="callback" prompt auto-login />
 </template>

--- a/tabu-app/src/components/LoginItem.vue
+++ b/tabu-app/src/components/LoginItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { decodeCredential, GoogleLogin } from 'vue3-google-login'
 import type { CallbackTypes } from 'vue3-google-login'
-import { googleLogin } from '@/services/auth/google'
+import { loginWithGoogle } from '@/services/auth/google'
 import router from '@/router'
 
 type GoogleUserData = {
@@ -14,12 +14,11 @@ const callback: CallbackTypes.CredentialCallback = async response => {
   const userData: GoogleUserData = decodeCredential(
     response.credential,
   ) as GoogleUserData
-  googleLogin(userData.given_name, userData.email).then(function (resp) {
+  loginWithGoogle(userData.given_name, userData.email).then(function (resp) {
     if (resp.data.success) {
       console.log('Successfully logged in', resp.data.response)
       const localUser = {
         name: resp.data.response.name,
-        email: resp.data.response.email,
       }
       localStorage.setItem('userData', JSON.stringify(localUser))
       router.push({ path: 'home' })

--- a/tabu-app/src/main.ts
+++ b/tabu-app/src/main.ts
@@ -3,9 +3,13 @@ import './assets/main.css'
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
+import vue3GoogleLogin from 'vue3-google-login'
 
 const app = createApp(App)
 
 app.use(router)
+app.use(vue3GoogleLogin, {
+  clientId: import.meta.env.VITE_APP_GOOGLE_CLIENT_ID,
+})
 
 app.mount('#app')

--- a/tabu-app/src/router/index.ts
+++ b/tabu-app/src/router/index.ts
@@ -1,13 +1,20 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import HomeView from '../views/HomeView.vue'
+import HomeView from '@/views/HomeView.vue'
+import LoginView from '@/views/LoginView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',
+      alias: '/home',
       name: 'home',
       component: HomeView,
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: LoginView,
     },
     {
       path: '/about',

--- a/tabu-app/src/services/api.ts
+++ b/tabu-app/src/services/api.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const instance = axios.create({
+  baseURL: import.meta.env.VITE_API_ENDPOINT,
+  timeout: 2000,
+  headers: { 'X-Custom-Header': 'foobar' },
+})
+export default instance

--- a/tabu-app/src/services/auth/google.ts
+++ b/tabu-app/src/services/auth/google.ts
@@ -1,11 +1,15 @@
 // the axios instance and types
 import http from '../api'
 
-async function googleLogin(name: string, email: string) {
+async function loginWithGoogle(name: string, email: string) {
   return await http({
-    url: 'api/oauth/login/google/callback',
+    url: 'api/user/check',
     method: 'POST',
-    headers: {},
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    },
     data: {
       isGoogleLogin: true,
       email: email,
@@ -14,4 +18,4 @@ async function googleLogin(name: string, email: string) {
   })
 }
 
-export { googleLogin }
+export { loginWithGoogle }

--- a/tabu-app/src/services/auth/google.ts
+++ b/tabu-app/src/services/auth/google.ts
@@ -1,0 +1,17 @@
+// the axios instance and types
+import http from '../api'
+
+async function googleLogin(name: string, email: string) {
+  return await http({
+    url: 'api/oauth/login/google/callback',
+    method: 'POST',
+    headers: {},
+    data: {
+      isGoogleLogin: true,
+      email: email,
+      name: name,
+    },
+  })
+}
+
+export { googleLogin }

--- a/tabu-app/src/services/types.ts
+++ b/tabu-app/src/services/types.ts
@@ -1,0 +1,5 @@
+export type APIResponse<T> = {
+  success: boolean
+  content: T
+  status?: number
+}

--- a/tabu-app/src/views/LoginView.vue
+++ b/tabu-app/src/views/LoginView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import HomeItem from '@/components/HomeItem.vue'
+import Login from '@/components/LoginItem.vue'
 </script>
 
 <template>
   <main>
-    <HomeItem></HomeItem>
+    <Login />
   </main>
 </template>


### PR DESCRIPTION
Add HomeItem for rendering logged in user details
Add initial API call for login with Axios
Add vue3-google-login lib and set it up for google login
Add basic env key-value pairs

Tested with backend PR: https://github.com/tabu-hr/tabu-db-api/pull/5
The API doesn't yet bind data to particular user, but it can be fetched for testing, alternative is to mock data coming in and
start creating UI

Should not be merged yet, but opened to get more feedback about architecture and structure

TODO: 
- Finalize login component UI
- Remove side-by-side rendering and make proper routing
- Decide on ways to store data on client side (in general, for user login, JWT or some key can be saved to a cookie and persisted as required, for now its just set to local storage)


